### PR TITLE
Improve TSV reader path handling and add CLI

### DIFF
--- a/funciontsv.py
+++ b/funciontsv.py
@@ -1,15 +1,16 @@
+from pathlib import Path
 import pandas as pd
 import ast
 
 
-def listsFromTSV(path="C:\\Users\\USER\\ICN\\monitoring_DB.tsv", run_ids=None):
+def listsFromTSV(path: str | None = None, run_ids=None):
     """Parse the TSV file and return lists of selected columns.
 
     Parameters
     ----------
-    path : str, optional
-        Path to the TSV file. Defaults to the original location used by the
-        script.
+    path : str | Path | None, optional
+        Path to the TSV file. If ``None`` the file ``monitoring_DB.tsv``
+        located alongside this script is used.
     run_ids : int | list[int] | None, optional
         ``RUNID`` or collection of ``RUNID`` values to select. If ``None`` all
         rows are processed.
@@ -21,6 +22,12 @@ def listsFromTSV(path="C:\\Users\\USER\\ICN\\monitoring_DB.tsv", run_ids=None):
         ``listaDataOK`` – list of integer lists from the "Data OK" column,
         ``listaGain`` – list of float lists from the "Gain" column.
     """
+
+    # Determine path to TSV file
+    if path is None:
+        path = Path(__file__).with_name("monitoring_DB.tsv")
+    else:
+        path = Path(path)
 
     # Read TSV and normalize header spacing
     df = pd.read_csv(path, sep="\t", dtype=str, keep_default_na=False)
@@ -97,11 +104,27 @@ def listsFromTSV(path="C:\\Users\\USER\\ICN\\monitoring_DB.tsv", run_ids=None):
         listaGain.append(vals)
 
     return listaMCMid, listaDataOK, listaGain
+    
 
+if __name__ == "__main__":
+    import argparse
 
-# Example usage:
-# listaMCMid, listaDataOK, listaGain = listsFromTSV(run_ids=211)
-# mcmid_first_row = listaMCMid[0]
-# dataok_first_row = listaDataOK[0]
-# gain_first_row = listaGain[0]
+    parser = argparse.ArgumentParser(description="Read monitoring TSV data")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Path to TSV file (defaults to monitoring_DB.tsv next to the script)",
+    )
+    parser.add_argument(
+        "--run-ids",
+        nargs="*",
+        type=int,
+        help="Optional RUNID values to select",
+    )
+    args = parser.parse_args()
+
+    mcmid, data_ok, gain = listsFromTSV(args.path, args.run_ids)
+    print(mcmid)
+    print(data_ok)
+    print(gain)
 


### PR DESCRIPTION
## Summary
- Use `pathlib.Path` to resolve TSV files relative to the script for cross-platform compatibility
- Add a simple command-line interface for choosing the TSV path and run IDs

## Testing
- `python -m py_compile funciontsv.py`
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python funciontsv.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ade8688af083248b3e52db4e42a951