### PR TITLE
Handle alphanumeric MCMIDs and empty results

### DIFF
--- a/funciontsv.py
+++ b/funciontsv.py
@@ -48,12 +48,14 @@ def listsFromTSV(path: str | None = None, run_ids=None, mcm_ids=None):
         df = df.loc[df[mcm_col].astype(str).str.strip().isin(norm_mcm)]
 
     # Build outputs
-    listaMCMid = (
-        pd.to_numeric(df[mcm_col].str.strip(), errors="coerce")
-        .dropna()
-        .astype(int)
-        .tolist()
-    )
+    # Keep alphanumeric MCMIDs instead of dropping non-numeric values
+    listaMCMid = []
+    for val in df[mcm_col].astype(str).str.strip():
+        try:
+            listaMCMid.append(int(val))
+        except ValueError:
+            if val:
+                listaMCMid.append(val)
 
     listaDataOK: list[list[int]] = []
     for cell in df[dok_col].tolist():
@@ -82,8 +84,8 @@ def listsFromTSV(path: str | None = None, run_ids=None, mcm_ids=None):
     # Flatten listaDataOK
     listaDataOK = [item for sublist in listaDataOK for item in sublist]
 
-    for _ in range(len(listaDataOK)-1):
-        listaMCMid.append(listaMCMid[0])
+    if listaMCMid and len(listaMCMid) == 1:
+        listaMCMid = [listaMCMid[0]] * len(listaDataOK)
     
     # Flatten listaGain
     listaGain = [item for sublist in listaGain for item in sublist]


### PR DESCRIPTION
## Summary
- allow reading MCMIDs that contain letters instead of dropping them
- avoid IndexError when no records match by safely repeating MCM IDs

## Testing
- `pip install pandas` *(fails: Could not connect to proxy)*
- `python funciontsv.py --run-ids 216 --mcm-ids 48B` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68ae028bb7c88324ab8c1c925b92a470